### PR TITLE
Add user_id filter to /data_access/list_received

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,7 +109,9 @@ async def list_granted_data_access_route(
         request.state.acl, organisation_id)
 
 @app.get("/data_access/list_received", tags=["data_access"], status_code=200)
-async def list_received_data_access_route(request: Request):
+async def list_received_data_access_route(request: Request, user_id: str | None = None):
+    if user_id:
+        return list_received_data_access.list_received_data_access_for_user(request.state.acl, user_id)
     return list_received_data_access.list_received_data_access(request.state.acl)
 
 @app.get("/organisation/yearly_cost_overview", tags=["organisation"])

--- a/organisation/list_received_data_access.py
+++ b/organisation/list_received_data_access.py
@@ -1,11 +1,32 @@
 from organisation.view_data_access import convert_data_access_row
 from organisation import db
 
-from acl import acl
+from acl import acl, get_acl
 from fastapi import HTTPException
 from pydantic import BaseModel
 
 # Any user is allowed to receive this data
 def list_received_data_access(acl_user: acl.ACL):
     rows = db.list_received_data_access(acl_user.part_of_organisation, acl_user.user_id)
+    return list(map(lambda row: convert_data_access_row(row=row), rows))
+
+def is_allowed_to_list_received_data_access_for_user(acl_user: acl.ACL, organisation_id: int):
+    if acl_user.is_admin == True:
+        return True
+    if acl_user.part_of_organisation == organisation_id:
+        return True
+    return False
+
+# List the data access received by a specific user (their organisation grants
+# + grants made directly to that user). Used by admins/organisation-admins to
+# inspect what data another user can access.
+def list_received_data_access_for_user(acl_user: acl.ACL, user_id: str):
+    target_acl = get_acl.get_acl_for_user_id(user_id)
+    if target_acl == None:
+        raise HTTPException(status_code=404, detail="user not found")
+
+    if not is_allowed_to_list_received_data_access_for_user(acl_user=acl_user, organisation_id=target_acl.part_of_organisation):
+        raise HTTPException(status_code=403, detail="user not authorized to list received data access for this user")
+
+    rows = db.list_received_data_access(target_acl.part_of_organisation, target_acl.user_id)
     return list(map(lambda row: convert_data_access_row(row=row), rows))


### PR DESCRIPTION
Allow admins and organisation-admins to inspect which data another user can access by passing an optional user_id query parameter. The DB layer already supported filtering received grants by (organisation_id, user_id); this exposes it through the existing route with a permission check that mirrors list_users (admin, or same organisation as the target user).